### PR TITLE
Fix up tests since code has changed

### DIFF
--- a/server/Lobby.js
+++ b/server/Lobby.js
@@ -88,7 +88,7 @@ Lobby.prototype.handleUsernameChange = function(msg) {
  */
 Lobby.prototype.handlePlayerJoin = function(msg) {
     if (this.players.length < MAX_PLAYERS) {
-        let player = new Player(msg.sourceID, Utils.generateRandomString(8), this.picker.pickColor());
+        let player = new Player(msg.sourceID, Utils.generateRandomString(8), this.picker.pickColor(), false);
         this.players.push(player);
 
         // Informs the other players in the lobby that a new player has joined

--- a/shared/Player.js
+++ b/shared/Player.js
@@ -17,18 +17,6 @@
 }
 
 /**
- * @constructor
- * @param {String} id Unique, secret identifier of this player
- * @param {String} color Stores player's color as in integer representation of hex code
- */
-function Player(id, username, color) {
-   this.id = id;
-   this.username = username;
-   this.color = color;
-   this.ready = false;
-}
-
-/**
  * Converts this object to a dictionary.
  * @return {String}
  */

--- a/test/message.js
+++ b/test/message.js
@@ -1,14 +1,16 @@
 const assert = require("assert");
 const Message = require("../shared/Message.js")
 const MessageType = require("../shared/MessageType.js")
+const LobbyState = require("../shared/LobbyState.js")
 
 
 describe('Message', function() {
-  let m = new Message("asdrlkda", "wqkrlamn", MessageType.USERNAME, "opwnjhqa", {username: "Bob"});
+  let m = new Message("asdrlkda", "wqkrlamn", MessageType.USERNAME, "opwnjhqa", {username: "Bob", state: LobbyState.LOBBY});
 
   it("Should convert to JSON", function() {
     let json = m.toJSON();
-    assert.strictEqual(json, '{"targetID":"asdrlkda","sourceID":"wqkrlamn","type":"username","lobbyID":"opwnjhqa","data":{"username":"Bob"}}');
+    let expected =  '{"targetID":"asdrlkda","sourceID":"wqkrlamn","type":"username","lobbyID":"opwnjhqa","data":{"username":"Bob","state":"lobby"}}';
+    assert.strictEqual(json, expected);
   });
 
   it("Should convert from JSON to an equal object", function() {

--- a/test/player.js
+++ b/test/player.js
@@ -4,13 +4,18 @@ const Player = require("../shared/Player.js")
 describe('Player', function() {
   let p = new Player("asdlkda", "Bob", "#FF0000", false, true);
 
-  it("Should convert to JSON", function() {
-    let json = p.toJSON();
-    assert.strictEqual(json, '{"id":"asdlkda","username":"Bob","color":"#FF0000","ready":false,"isOwner":true}');
+  it("Should convert to dictionary", function() {
+    let actual = p.toDict();
+    let expected = {id:"asdlkda",username:"Bob",color:"#FF0000",ready:false};
+    assert.deepStrictEqual(actual, expected);
   });
 
-  it("Should convert from JSON to an equal object", function() {
-    assert.deepStrictEqual(Player.fromJSON(p.toJSON()), p);
+  it("Should convert from dictionary to an equal object", function() {
+    assert.deepStrictEqual(Player.fromJSON(JSON.stringify(p.toDict())), p);
   });
 
+  it("Should convert to a string", function() {
+    let expected = '{"id":"asdlkda","username":"Bob","color":"#FF0000","ready":false}';
+    assert.strictEqual(p.toString(), expected);
+  });
 });

--- a/test/settings.js
+++ b/test/settings.js
@@ -13,4 +13,7 @@ describe('Settings', function() {
     assert.deepStrictEqual(Settings.fromJSON(s.toJSON()), s);
   });
 
+  it("Should convert from dictionary to an equal object", function() {
+    assert.deepStrictEqual(Settings.fromJSON(JSON.stringify(s.toDict())), s);
+  });
 });

--- a/test/testUniqueColorPicker.js
+++ b/test/testUniqueColorPicker.js
@@ -45,4 +45,8 @@ describe('UniqueColorPicker', function() {
     assert.strictEqual(p2.pickColor(), "#000000");
   });
 
+  it("Should not crash if asked to free nonexistent color", function() {
+    p1.freeColor("#SDSDKJ");
+  });
+
 });


### PR DESCRIPTION
Some small tests. The code coverage missing is because of the 

```
if (typeof module === 'object') {
    module.exports = Player;
} else {
    window.Player = Player;
}
```

You would have to test in a webrowser for this code to run? Can ignore this for now

```
> hivemind@1.0.0 test
> nyc mocha

  Message
    ✔ Should convert to JSON
    ✔ Should convert from JSON to an equal object

  Player
    ✔ Should convert to dictionary
    ✔ Should convert from dictionary to an equal object
    ✔ Should convert to a string

  Settings
    ✔ Should convert to JSON
    ✔ Should convert from JSON to an equal object
    ✔ Should convert from dictionary to an equal object

  UniqueColorPicker
    ✔ Should have different color orders
    ✔ Should have the last color be the one that was freed
Error: No colors available
Error: No colors available
    ✔ Should return black if there are no more colors
Error: Color #SDSDKJ not found
    ✔ Should not crash if asked to free nonexistent color


  12 passing (5ms)

-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------|---------|----------|---------|---------|-------------------
All files              |   94.18 |    64.28 |     100 |   94.04 |                   
 server                |     100 |      100 |     100 |     100 |                   
  UniqueColorPicker.js |     100 |      100 |     100 |     100 |                   
 shared                |   90.19 |       50 |     100 |   90.19 |                   
  LobbyState.js        |      75 |       50 |     100 |      75 | 16                
  Message.js           |   92.85 |       50 |     100 |   92.85 | 53                
  MessageType.js       |      75 |       50 |     100 |      75 | 21                
  Player.js            |   93.33 |       50 |     100 |   93.33 | 55                
  Settings.js          |   92.85 |       50 |     100 |   92.85 | 50                
-----------------------|---------|----------|---------|---------|-------------------

```